### PR TITLE
Fix: Add missing CSV headers for new LinkedIn export format

### DIFF
--- a/with_linkedin_data_export/index.html
+++ b/with_linkedin_data_export/index.html
@@ -28,7 +28,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-csv/1.0.11/jquery.csv.min.js"></script>
 <script>
-    const LINKED_IN_CSV_HEADER = 'First Name,Last Name,Email Address,Company';
+    const LINKED_IN_CSV_HEADER = 'First Name,Last Name,URL,Email Address,Company,Position,Connected On';
     const MINIMUM_COMPANY_SIZE = 3;
     const fileInput = document.getElementById("csv");
     const nodes = [];


### PR DESCRIPTION
The previous CSV structure was deprecated. The new LinkedIn export adds three headers: `URL`, `Position`, and `Connected On`. 

The updated header is now:
`First Name,Last Name,URL,Email Address,Company,Position,Connected On`

Referred Issue : #1  